### PR TITLE
Create basic CICD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,49 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This is the top-level workflow that runs on each pull request and push to main.
+# It invokes other jobs to perform builds and possibly run tests.
+# All jobs run in parallel, using build artifacts to synchronize jobs.
+
+name: CI/CD
+
+on:
+  # Run on a daily schedule to perform the full set of tests.
+  schedule:
+    - cron: '00 8 * * *'
+  # Run on pull request to validate code changes.
+  pull_request:
+  merge_group:
+  # Permit manual runs of the workflow.
+  workflow_dispatch:
+  # Run on push so we can capture the baseline code coverage.
+  push:
+    branches: [ main ]
+
+concurrency:
+  # Cancel any in-progress instance of this workflow (CI/CD) for the same PR.
+  # Allow running concurrently with any commits on any other branch.
+  # Using GITHUB_REF instead of GITHUB_SHA allows parallel runs on
+  # different branches with the same HEAD commit.
+  group: cicd-${{ github.event.schedule || github.event.pull_request.number || github.event.after || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+
+jobs:
+  # Jobs to run on pull, push, and schedule.
+  # ---------------------------------------------------------------------------
+
+  # Perform the regular build.
+  regular:
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+      build_artifact: Build-x64
+      configurations: '["Debug", "Release"]'
+
+  # Add more jobs here to run additional tests, such as code coverage, fuzzing, etc.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 
 # This is the top-level workflow that runs on each pull request and push to main.
 # It invokes other jobs to perform builds and possibly run tests.

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 
 # This workflow performs a build of the project and uploads the result as a build artifact.
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This workflow performs a build of the project and uploads the result as a build artifact.
+
+name: Reusable MSBuild Workflow
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      # repository to be used (needed for self-hosted runner setups)
+      repository:
+        required: true
+        type: string
+      # Name associated with the output of this build.
+      build_artifact:
+        required: true
+        type: string
+      # Additional options passed to msbuild.
+      build_options:
+        required: false
+        type: string
+      configurations:
+        required: false
+        type: string
+        default: '["Debug", "Release"]'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    timeout-minutes: 90
+
+    strategy:
+      matrix:
+        configurations: ${{ fromJSON(inputs.configurations) }}
+
+    runs-on: windows-2022
+    env:
+      # Path to the solution file relative to the root of the project.
+      SOLUTION_FILE_PATH: ctsTraffic.sln
+      BUILD_ARTIFACT_NAME: ${{inputs.build_artifact}}
+      BUILD_CONFIGURATION: ${{matrix.configurations}}
+      BUILD_PLATFORM: x64
+      BUILD_OPTIONS: ${{inputs.build_options}}
+      CXX_FLAGS: ${{inputs.cxx_flags}}
+      LD_FLAGS: ${{inputs.ld_flags}}
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      if: steps.skip_check.outputs.should_skip != 'true'
+      with:
+        repository: ${{inputs.repository}}
+        submodules: 'recursive'
+        ref: ${{inputs.ref}}
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
+
+    - name: Nuget Restore
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      run: msbuild /p:Configuration=${{matrix.configurations}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.BUILD_OPTIONS}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+      with:
+        name: ${{env.BUILD_ARTIFACT_NAME}} ${{env.BUILD_CONFIGURATION}}
+        path: 'x64/${{env.BUILD_CONFIGURATION}}'
+
+    


### PR DESCRIPTION
This pull request introduces significant changes to the Continuous Integration/Continuous Deployment (CI/CD) process of the project. The changes include the addition of a new top-level workflow `cicd.yml` that runs on each pull request and push to the main branch, and a reusable workflow `reusable-build.yml` that performs a build of the project and uploads the result as a build artifact.

Key Changes:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0R1-R49): Introduced a new top-level CI/CD workflow that runs on a daily schedule, pull request, manual dispatch, and push to the main branch. It performs builds and possibly runs tests using other jobs. It also ensures that any in-progress instance of this workflow for the same PR is cancelled to allow running concurrently with any commits on any other branch.

* [`.github/workflows/reusable-build.yml`](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R1-R81): Added a reusable workflow that is called by the top-level workflow. This workflow performs a build of the project and uploads the result as a build artifact. It allows for the specification of the repository, build artifact name, build options, and configurations as inputs.