### PR TITLE
Udp push

### DIFF
--- a/ctsTraffic/ctsMediaStreamInterfaces.hpp
+++ b/ctsTraffic/ctsMediaStreamInterfaces.hpp
@@ -1,0 +1,150 @@
+/*
+
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+
+*/
+
+/*
+  Media Stream Interfaces
+
+  Minimal interfaces for sender and receiver roles used by the media-stream
+  refactor. The goal is to introduce a small, stable abstraction boundary so
+  sender/receiver implementations can be moved into separate translation units
+  without changing the protocol/IO semantics.
+
+  Ownership and lifetime rules are documented below and must be preserved by
+  implementations to avoid introducing races or hidden-threading behavior.
+*/
+
+#pragma once
+
+#include <memory>
+#include <functional>
+#include <cstdint>
+#include <WinSock2.h>
+
+#include "ctsIOTask.hpp"
+#include "ctsSocket.h"
+#include "ctsMediaStreamProtocol.hpp"
+#include "ctsWinsockLayer.h"
+
+namespace ctsTraffic
+{
+// Forward: ctSockaddr is in ctl::ctSockaddr (included via protocol/header files)
+
+// NOTE: These interfaces purposely remain small and procedural.
+// - Do not add thread creation or hidden background work to implementations.
+// - Caller is responsible for scheduling and calling the appropriate methods
+//   on the expected threads (for example: timer callback for sync server sends
+//   or the IO completion thread for async client sends).
+
+class IMediaStreamSender
+{
+public:
+    virtual ~IMediaStreamSender() = default;
+
+    // Initialize the sender for a particular connection context.
+    // - `controlSocket` is the weak reference to the ctsSocket used to report
+    //   completion of the connection state. Implementations should lock the
+    //   weak_ptr only for short-lived operations and must not assume it remains
+    //   valid beyond a single call.
+    // - `sendingSocket` is the OS SOCKET that should be used for datagram
+    //   sends. The sender does NOT own this SOCKET and must not close it.
+    // - `remoteAddr` is the target address for outgoing datagrams.
+    virtual bool Initialize(
+        std::weak_ptr<ctsSocket> controlSocket,
+        SOCKET sendingSocket,
+        const ctl::ctSockaddr& remoteAddr) noexcept = 0;
+
+    // Perform a synchronous send for the provided task. This mirrors the
+    // server-side code path that performs synchronous WSASendTo calls inside
+    // the timer callback. The returned `wsIOResult` encapsulates bytes
+    // transferred and an error code (consistent with `ctsWinsockLayer` helpers).
+    // - Must complete before returning (synchronous contract).
+    virtual wsIOResult SendSync(const ctsTask& task) noexcept = 0;
+
+    // Initiate an asynchronous send. This mirrors the client code path which
+    // uses an async send helper and a completion callback.
+    // - Implementations should return a `wsIOResult` to communicate whether
+    //   the operation completed inline or is pending; if pending, the provided
+    //   completion callback must be invoked when finished.
+    // - The completion callback must be invoked exactly once if the operation
+    //   returns WSA_IO_PENDING; it may be invoked inline if the operation
+    //   completes synchronously.
+    virtual wsIOResult SendAsync(const ctsTask& task, std::function<void(wsIOResult)>&& completion) noexcept = 0;
+
+    // Lifecycle helpers. Start/Stop are lightweight and must not spawn threads.
+    virtual void Start() noexcept = 0;
+    virtual void Stop() noexcept = 0;
+};
+
+class IMediaStreamReceiver
+{
+public:
+    virtual ~IMediaStreamReceiver() = default;
+
+    // Called when a datagram is received on a listening socket. The receiver
+    // may synchronously parse the datagram and take any protocol action
+    // required (for example: processing a START, or interpreting a data
+    // frame). Implementations must NOT hold the `buffer` pointer beyond the
+    // lifetime of this call; if retention is required the data must be copied.
+    virtual void OnDatagram(const char* buffer, uint32_t length, const ctl::ctSockaddr& remoteAddr) noexcept = 0;
+
+    // Lifecycle helpers. Start/Stop must be cheap and not create threads.
+    virtual void Start() noexcept = 0;
+    virtual void Stop() noexcept = 0;
+};
+
+/*
+Ownership and lifetime summary
+--------------------------------
+- Buffers passed in `ctsTask` or as raw pointers to `OnDatagram`:
+  - Caller (the IO layer / ctsThreadIocp) owns the memory backing the buffer.
+  - Implementations must treat buffer pointers as transient and not reference
+    them after the call returns. To retain payloads, explicitly copy into
+    owned storage (for example, a std::vector or a heap allocation).
+
+- SOCKET ownership:
+  - The `sendingSocket` passed to `Initialize` is not owned by the sender.
+  - Do not call `closesocket` on that SOCKET; the owner (server listener)
+    manages its lifecycle.
+
+- Stream object ownership:
+  - Higher-level components (server `ctsMediaStreamServerImpl`, the
+    `ctsMediaStreamServerConnectedSocket`, or client code) are responsible
+    for creating and owning sender/receiver instances. Use `std::shared_ptr`
+    to manage shared lifetime when multiple components may hold references.
+  - Implementations should be safe to destroy on any thread; destruction must
+    not block waiting for background work because implementations must not
+    create hidden background threads. If an implementation needs to cancel
+    in-flight operations, `Stop()` should be used by the owner prior to
+    destruction.
+
+Threading contract
+------------------
+- Callers must preserve the existing IO threading model:
+  - `SendSync` will be called from the server timer callback (synchronous)
+    and must complete before returning.
+  - `SendAsync` will be called from client code paths that expect async
+    behaviour and a completion callback on the IO thread.
+  - `OnDatagram` will be invoked from the listening socket's IO completion
+    handling thread — keep handlers efficient.
+
+Adapters & factories
+--------------------
+Implementations can expose factory functions (free functions or static
+creators) that return `std::shared_ptr<IMediaStreamSender>` /
+`std::shared_ptr<IMediaStreamReceiver>` to simplify construction. Doing so
+keeps ownership explicit and makes wiring into `ctsMediaStreamServerImpl` and
+`ctsMediaStreamServerConnectedSocket` straightforward.
+
+*/
+
+} // namespace ctsTraffic

--- a/ctsTraffic/ctsMediaStreamSend.cpp
+++ b/ctsTraffic/ctsMediaStreamSend.cpp
@@ -14,8 +14,13 @@ See the Apache Version 2.0 License for specific language governing permissions a
 #include "ctsMediaStreamSend.h"
 #include "ctsMediaStreamProtocol.hpp"
 #include "ctsConfig.h"
+<<<<<<< HEAD
 #include <Windows.h>
 #include <WinSock2.h>
+=======
+#include <WinSock2.h>
+#include <Windows.h>
+>>>>>>> 2f79fdc (refactor(media): extract server send logic into ctsMediaStreamSend implementation)
 
 namespace ctsTraffic
 {

--- a/ctsTraffic/ctsMediaStreamSend.cpp
+++ b/ctsTraffic/ctsMediaStreamSend.cpp
@@ -1,0 +1,124 @@
+/*
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+*/
+
+// Implementation of the server-side send extraction
+
+#include "ctsMediaStreamSend.h"
+#include "ctsMediaStreamProtocol.hpp"
+#include "ctsConfig.h"
+#include <Windows.h>
+#include <WinSock2.h>
+
+namespace ctsTraffic
+{
+    wsIOResult ConnectedSocketSendImpl(_In_ ctsMediaStreamServerConnectedSocket* connectedSocket) noexcept
+    {
+        const SOCKET socket = connectedSocket->GetSendingSocket();
+        if (INVALID_SOCKET == socket)
+        {
+            return wsIOResult(WSA_OPERATION_ABORTED);
+        }
+
+        const ctl::ctSockaddr& remoteAddr(connectedSocket->GetRemoteAddress());
+        const ctsTask nextTask = connectedSocket->GetNextTask();
+
+        wsIOResult returnResults;
+        if (ctsTask::BufferType::UdpConnectionId == nextTask.m_bufferType)
+        {
+            // making a synchronous call
+            WSABUF wsaBuffer;
+            wsaBuffer.buf = nextTask.m_buffer;
+            wsaBuffer.len = nextTask.m_bufferLength;
+
+            const auto sendResult = WSASendTo(
+                socket,
+                &wsaBuffer,
+                1,
+                &returnResults.m_bytesTransferred,
+                0,
+                remoteAddr.sockaddr(),
+                remoteAddr.length(),
+                nullptr,
+                nullptr);
+
+            if (SOCKET_ERROR == sendResult)
+            {
+                const auto error = WSAGetLastError();
+                ctsConfig::PrintErrorInfo(
+                    L"WSASendTo(%Iu, %ws) for the Connection-ID failed [%d]",
+                    socket,
+                    remoteAddr.writeCompleteAddress().c_str(),
+                    error);
+                return wsIOResult(error);
+            }
+        }
+        else
+        {
+            const auto sequenceNumber = connectedSocket->IncrementSequence();
+            ctsMediaStreamSendRequests sendingRequests(
+                nextTask.m_bufferLength, // total bytes to send
+                sequenceNumber,
+                nextTask.m_buffer);
+            for (auto& sendRequest : sendingRequests)
+            {
+                // making a synchronous call
+                DWORD bytesSent{};
+                const auto sendResult = WSASendTo(
+                    socket,
+                    sendRequest.data(),
+                    static_cast<DWORD>(sendRequest.size()),
+                    &bytesSent,
+                    0,
+                    remoteAddr.sockaddr(),
+                    remoteAddr.length(),
+                    nullptr,
+                    nullptr);
+                if (SOCKET_ERROR == sendResult)
+                {
+                    const auto error = WSAGetLastError();
+                    if (WSAEMSGSIZE == error)
+                    {
+                        uint32_t bytesRequested = 0;
+                        // iterate across each WSABUF* in the array
+                        for (const auto& wsaBuffer : sendRequest)
+                        {
+                            bytesRequested += wsaBuffer.len;
+                        }
+                        ctsConfig::PrintErrorInfo(
+                            L"WSASendTo(%Iu, seq %lld, %ws) failed with WSAEMSGSIZE : attempted to send datagram of size %u bytes",
+                            socket,
+                            sequenceNumber,
+                            remoteAddr.writeCompleteAddress().c_str(),
+                            bytesRequested);
+                    }
+                    else
+                    {
+                        ctsConfig::PrintErrorInfo(
+                            L"WSASendTo(%Iu, seq %lld, %ws) failed [%d]",
+                            socket,
+                            sequenceNumber,
+                            remoteAddr.writeCompleteAddress().c_str(),
+                            error);
+                    }
+                    return wsIOResult(error);
+                }
+
+                // successfully completed synchronously
+                returnResults.m_bytesTransferred += bytesSent;
+                PRINT_DEBUG_INFO(
+                    L"\t\tctsMediaStreamServer sending seq number %lld (%u sent-bytes, %u frame-bytes)\n",
+                    sequenceNumber, bytesSent, returnResults.m_bytesTransferred);
+            }
+        }
+
+        return returnResults;
+    }
+}

--- a/ctsTraffic/ctsMediaStreamSend.cpp
+++ b/ctsTraffic/ctsMediaStreamSend.cpp
@@ -14,13 +14,8 @@ See the Apache Version 2.0 License for specific language governing permissions a
 #include "ctsMediaStreamSend.h"
 #include "ctsMediaStreamProtocol.hpp"
 #include "ctsConfig.h"
-<<<<<<< HEAD
-#include <Windows.h>
-#include <WinSock2.h>
-=======
 #include <WinSock2.h>
 #include <Windows.h>
->>>>>>> 2f79fdc (refactor(media): extract server send logic into ctsMediaStreamSend implementation)
 
 namespace ctsTraffic
 {

--- a/ctsTraffic/ctsMediaStreamSend.h
+++ b/ctsTraffic/ctsMediaStreamSend.h
@@ -1,0 +1,27 @@
+/*
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+*/
+
+#pragma once
+
+// Minimal header exposing the server-side send implementation.
+
+#include <WinSock2.h>
+#include "ctsMediaStreamServerConnectedSocket.h"
+#include "ctsWinsockLayer.h"
+
+namespace ctsTraffic
+{
+    // Implements the send-side behavior for a connected media-stream socket.
+    // This function is a drop-in implementation that mirrors the existing
+    // `ConnectedSocketIo` logic and is intended to be used by refactor work
+    // to move send responsibilities into a separate translation unit.
+    wsIOResult ConnectedSocketSendImpl(_In_ ctsMediaStreamServerConnectedSocket* connectedSocket) noexcept;
+}

--- a/ctsTraffic/ctsMediaStreamServer.cpp
+++ b/ctsTraffic/ctsMediaStreamServer.cpp
@@ -29,6 +29,7 @@ See the Apache Version 2.0 License for specific language governing permissions a
 #include "ctsMediaStreamServerConnectedSocket.h"
 #include "ctsMediaStreamServerListeningSocket.h"
 #include "ctsMediaStreamProtocol.hpp"
+#include "ctsMediaStreamSend.h"
 // wil headers always included last
 #include <wil/stl.h>
 #include <wil/resource.h>
@@ -398,105 +399,10 @@ namespace ctsTraffic
 
         wsIOResult ConnectedSocketIo(_In_ ctsMediaStreamServerConnectedSocket* connectedSocket) noexcept
         {
-            const SOCKET socket = connectedSocket->GetSendingSocket();
-            if (INVALID_SOCKET == socket)
-            {
-                return wsIOResult(WSA_OPERATION_ABORTED);
-            }
-
-            const ctl::ctSockaddr& remoteAddr(connectedSocket->GetRemoteAddress());
-            const ctsTask nextTask = connectedSocket->GetNextTask();
-
-            wsIOResult returnResults;
-            if (ctsTask::BufferType::UdpConnectionId == nextTask.m_bufferType)
-            {
-                // making a synchronous call
-                WSABUF wsaBuffer;
-                wsaBuffer.buf = nextTask.m_buffer;
-                wsaBuffer.len = nextTask.m_bufferLength;
-
-                const auto sendResult = WSASendTo(
-                    socket,
-                    &wsaBuffer,
-                    1,
-                    &returnResults.m_bytesTransferred,
-                    0,
-                    remoteAddr.sockaddr(),
-                    remoteAddr.length(),
-                    nullptr,
-                    nullptr);
-
-                if (SOCKET_ERROR == sendResult)
-                {
-                    const auto error = WSAGetLastError();
-                    ctsConfig::PrintErrorInfo(
-                        L"WSASendTo(%Iu, %ws) for the Connection-ID failed [%d]",
-                        socket,
-                        remoteAddr.writeCompleteAddress().c_str(),
-                        error);
-                    return wsIOResult(error);
-                }
-            }
-            else
-            {
-                const auto sequenceNumber = connectedSocket->IncrementSequence();
-                ctsMediaStreamSendRequests sendingRequests(
-                    nextTask.m_bufferLength, // total bytes to send
-                    sequenceNumber,
-                    nextTask.m_buffer);
-                for (auto& sendRequest : sendingRequests)
-                {
-                    // making a synchronous call
-                    DWORD bytesSent{};
-                    const auto sendResult = WSASendTo(
-                        socket,
-                        sendRequest.data(),
-                        static_cast<DWORD>(sendRequest.size()),
-                        &bytesSent,
-                        0,
-                        remoteAddr.sockaddr(),
-                        remoteAddr.length(),
-                        nullptr,
-                        nullptr);
-                    if (SOCKET_ERROR == sendResult)
-                    {
-                        const auto error = WSAGetLastError();
-                        if (WSAEMSGSIZE == error)
-                        {
-                            uint32_t bytesRequested = 0;
-                            // iterate across each WSABUF* in the array
-                            for (const auto& wsaBuffer : sendRequest)
-                            {
-                                bytesRequested += wsaBuffer.len;
-                            }
-                            ctsConfig::PrintErrorInfo(
-                                L"WSASendTo(%Iu, seq %lld, %ws) failed with WSAEMSGSIZE : attempted to send datagram of size %u bytes",
-                                socket,
-                                sequenceNumber,
-                                remoteAddr.writeCompleteAddress().c_str(),
-                                bytesRequested);
-                        }
-                        else
-                        {
-                            ctsConfig::PrintErrorInfo(
-                                L"WSASendTo(%Iu, seq %lld, %ws) failed [%d]",
-                                socket,
-                                sequenceNumber,
-                                remoteAddr.writeCompleteAddress().c_str(),
-                                error);
-                        }
-                        return wsIOResult(error);
-                    }
-
-                    // successfully completed synchronously
-                    returnResults.m_bytesTransferred += bytesSent;
-                    PRINT_DEBUG_INFO(
-                        L"\t\tctsMediaStreamServer sending seq number %lld (%u sent-bytes, %u frame-bytes)\n",
-                        sequenceNumber, bytesSent, returnResults.m_bytesTransferred);
-                }
-            }
-
-            return returnResults;
+            // Forward to the extracted send implementation. This preserves the
+            // original function signature so existing call sites do not change
+            // while the implementation lives in a separate translation unit.
+            return ConnectedSocketSendImpl(connectedSocket);
         }
     }
 }

--- a/ctsTraffic/ctsTraffic.vcxproj
+++ b/ctsTraffic/ctsTraffic.vcxproj
@@ -408,6 +408,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ctsAcceptEx.cpp" />
+  <ClCompile Include="ctsMediaStreamSend.cpp" />
     <ClCompile Include="ctsConfig.cpp" />
     <ClCompile Include="ctsConnectByName.cpp" />
     <ClCompile Include="ctsConnectEx.cpp" />

--- a/docs/MediaStreamRefactorPlan.md
+++ b/docs/MediaStreamRefactorPlan.md
@@ -1,0 +1,118 @@
+# Media Stream Refactor Plan
+
+Goal
+----
+Extract media streaming send and receive logic into clear, reusable modules so that either the client or the server can act as the sender. Keep runtime behaviour unchanged by default and keep threading/IOCP contracts intact.
+
+Scope
+-----
+- Files inspected / in-scope:
+  - `ctsMediaStreamClient.cpp`, `ctsMediaStreamClient.h`
+  - `ctsMediaStreamServer.cpp`, `ctsMediaStreamServer.h`
+  - `ctsMediaStreamProtocol.hpp`
+  - `ctsMediaStreamServerConnectedSocket.*`
+  - `ctsMediaStreamServerListeningSocket.*`
+  - Any helpers referenced by those files (search term: `MediaStream`, `SendBuffer`, `RateLimit`, `packet`, `payload`)
+
+High-level approach
+-------------------
+1. Inventory current responsibilities: map functions and classes to "send" vs "receive" responsibilities.
+2. Define stable, small interfaces for send and receive roles (`IMediaStreamSender`, `IMediaStreamReceiver`).
+3. Move send-only code to `ctsMediaStreamSend.cpp/.h` and receive-only code to `ctsMediaStreamReceive.cpp/.h`.
+4. Update client and server components to depend on interfaces rather than concrete implementations; allow runtime selection of which side is sender.
+5. Update server connected/listening socket files to accept or create sender/receiver instances.
+6. Add/adjust unit tests and integration smoke tests. Update project files.
+
+Proposed interfaces (examples)
+-----------------------------
+These are minimal, illustrative signatures. Exact names and parameters will be refined during implementation to match existing types and threading contracts.
+
+// sender interface
+class IMediaStreamSender
+{
+public:
+    virtual ~IMediaStreamSender() = default;
+    // Begin streaming on the given socket or connection context
+    virtual void StartSending() = 0;
+    // Stop/pause sending; may block until in-flight packets are drained
+    virtual void StopSending() = 0;
+    // Push data (buffer ownership semantics to match current code)
+    virtual bool EnqueuePayload(const uint8_t* buffer, size_t length) = 0;
+};
+
+// receiver interface
+class IMediaStreamReceiver
+{
+public:
+    virtual ~IMediaStreamReceiver() = default;
+    // Called when a datagram is received
+    virtual void OnDatagram(const uint8_t* buffer, size_t length) = 0;
+    // Lifecycle hooks
+    virtual void StartReceiving() = 0;
+    virtual void StopReceiving() = 0;
+};
+
+Notes on threading and io
+------------------------
+- Preserve existing IOCP / RIO usage by keeping the same call sites where overlapped operations or RIO APIs are issued.
+- The sender/receiver modules should not create threads silently; prefer to accept executor/queue references or operate in-caller-thread as current code does.
+
+Migration steps (detailed)
+-------------------------
+1) Inventory (done first)
+   - Produce a short mapping (file -> classes/functions -> role). This reduces risk when moving code.
+2) Design interfaces (small header in `ctsMediaStreamProtocol.hpp` or a new `ctsMediaStreamInterfaces.hpp`)
+   - Decide on ownership and lifetimes (who owns buffers; who destroys the stream objects).
+3) Extract send implementation
+   - Create `ctsMediaStreamSend.h` / `ctsMediaStreamSend.cpp`.
+   - Move packetization and rate-limiting logic, plus send-queue management.
+   - Keep internal helper static/anonymous where possible to limit public surface.
+4) Extract receive implementation
+   - Create `ctsMediaStreamReceive.h` / `ctsMediaStreamReceive.cpp`.
+   - Move datagram parsing, validation, reassembly, and stats reporting.
+5) Hook up client/server
+   - Replace concrete code in `ctsMediaStreamClient.*` and `ctsMediaStreamServer.*` with calls that instantiate and use the interfaces.
+   - Add runtime flag or configuration option to choose which side is the sender.
+6) Update socket-layer files
+   - `ctsMediaStreamServerConnectedSocket.*` and `ctsMediaStreamServerListeningSocket.*` should accept a sender/receiver instance or factory.
+7) Update project files
+   - Add new .cpp/.h to `ctsTraffic.vcxproj` and ensure headers are findable.
+8) Tests & validation
+   - Update MSTest units to reference new headers.
+   - Add one integration test: client sends to server (default), and server sends to client (swapped sender) to verify symmetry.
+
+Acceptance criteria
+-------------------
+- Default behaviour unchanged when roles are not swapped.
+- New files compile and are included in `ctsTraffic.vcxproj`.
+- Unit tests that previously covered media streaming compile; integration smoke scenarios run.
+
+Risks and mitigations
+---------------------
+- Risk: Threading or lifetime changes introduce subtle data races.
+  - Mitigation: Keep IO and overlapped calls at the same call sites; do not change lifetimes during first refactor iteration.
+- Risk: API surface change breaks other modules.
+  - Mitigation: Keep interfaces minimal and provide adapters where necessary.
+
+Checklist (quick)
+-----------------
+- [ ] Inventory completed and mapped to roles
+- [ ] Interface header created and reviewed
+- [ ] `ctsMediaStreamSend.*` added and compiled
+- [ ] `ctsMediaStreamReceive.*` added and compiled
+- [ ] Client and server refactored to use interfaces
+- [ ] Project files updated and solution builds
+- [ ] Unit tests updated and passing
+
+Estimated effort
+----------------
+- Inventory & interface design: 1-2 hours
+- Extract send/receive: 2-4 hours each (depends on code entanglement)
+- Integration + tests + build fixes: 1-3 hours
+
+Next steps
+----------
+1. Review this document and confirm the interface style and the extraction filenames.
+2. I will start the inventory step and list the exact functions/classes mapped to send/receive roles.
+
+If you approve, say "Proceed with inventory" and I'll begin inspecting the code and update the todo progress.

--- a/docs/MediaStreamRefactorPlan.md
+++ b/docs/MediaStreamRefactorPlan.md
@@ -108,7 +108,7 @@ Checklist (quick)
 -----------------
 - [X] Inventory completed and mapped to roles
 - [X] Interface header created and reviewed
-- [ ] `ctsMediaStreamSend.*` added and compiled
+- [X] `ctsMediaStreamSend.*` added and compiled
 - [ ] `ctsMediaStreamReceive.*` added and compiled
 - [ ] Client and server refactored to use interfaces
 - [ ] Project files updated and solution builds

--- a/docs/MediaStreamRefactorPlan.md
+++ b/docs/MediaStreamRefactorPlan.md
@@ -1,5 +1,15 @@
 # Media Stream Refactor Plan
 
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+
+
 Goal
 ----
 Extract media streaming send and receive logic into clear, reusable modules so that either the client or the server can act as the sender. Keep runtime behaviour unchanged by default and keep threading/IOCP contracts intact.
@@ -96,8 +106,8 @@ Risks and mitigations
 
 Checklist (quick)
 -----------------
-- [ ] Inventory completed and mapped to roles
-- [ ] Interface header created and reviewed
+- [X] Inventory completed and mapped to roles
+- [X] Interface header created and reviewed
 - [ ] `ctsMediaStreamSend.*` added and compiled
 - [ ] `ctsMediaStreamReceive.*` added and compiled
 - [ ] Client and server refactored to use interfaces
@@ -160,7 +170,3 @@ Important constraints for refactoring
 - Minimize API changes across the codebase: introduce small interfaces and adapters rather than changing existing call sites extensively.
 - Ensure lifetime and ownership of sockets and buffers remain consistent with current `ctsSocket` and `ctsTask` semantics to avoid races.
 
-Next recommended step
-- Draft a small interface header `ctsMediaStreamInterfaces.hpp` that exposes `IMediaStreamSender` and `IMediaStreamReceiver` (minimal methods), and provide adapter examples showing how `ctsMediaStreamServerConnectedSocket` and `ctsMediaStreamClient` would call into those interfaces.
-
-If you'd like, I can now create that interface header and small adapter examples. Say "Create interfaces" to proceed.


### PR DESCRIPTION
This pull request introduces a significant refactor to the media stream sending logic by extracting the server-side send implementation into its own translation unit, and introduces new minimal interfaces for media stream senders and receivers. The changes are focused on improving code modularity, maintainability, and clarity of ownership and threading contracts.

**Key changes:**

### Media Stream Abstractions

* Added new minimal interfaces `IMediaStreamSender` and `IMediaStreamReceiver` in `ctsMediaStreamInterfaces.hpp` to clearly define the responsibilities, ownership, and threading contracts for media stream senders and receivers. These interfaces are designed to be small, procedural, and avoid hidden threading or background work.

### Code Refactoring and Modularity

* Extracted the server-side send implementation from `ctsMediaStreamServer.cpp` into a new file `ctsMediaStreamSend.cpp`, with its interface declared in `ctsMediaStreamSend.h`. This isolates the send logic, making it easier to maintain and refactor further. [[1]](diffhunk://#diff-93f7c3927531169a5f87ea5bb8fdc6056fbbee7460d94aa800e670e18cdcc134R1-R124) [[2]](diffhunk://#diff-176f6ceef4d77d5edad404b846eb70cd5f081ce08854639e5216f7067077da5aR1-R27)
* Updated the project file `ctsTraffic.vcxproj` to include the new `ctsMediaStreamSend.cpp` translation unit in the build.

### Integration and Cleanup

* Updated `ctsMediaStreamServer.cpp` to use the new send implementation by calling `ConnectedSocketSendImpl`, removing the in-place send logic and forwarding calls to the extracted function. [[1]](diffhunk://#diff-5427e3c6509e287f5feaef7ce5eb1566c927caa40ef9854a10f1a108bdca9a11R32) [[2]](diffhunk://#diff-5427e3c6509e287f5feaef7ce5eb1566c927caa40ef9854a10f1a108bdca9a11L401-R405)

These changes lay the groundwork for further modularization and make the codebase easier to extend and maintain.