### PR TITLE
3-way sync proposal

### DIFF
--- a/documents/media_streaming_protocol_migration_plan.md
+++ b/documents/media_streaming_protocol_migration_plan.md
@@ -1,0 +1,197 @@
+Media Streaming Protocol — Implementation Migration Plan
+
+Goal
+
+Migrate the implementation from the legacy discovery model that used a 5-byte `START` discovery token to the new, integrated 3‑way handshake (SYN / SYN-ACK / ACK) defined in `media_streaming_protocol_spec_3way.md`.
+
+Important: do NOT replace the existing behavior by default. The new 3‑way handshake must be added as an optional, additive behavior controlled at runtime via a command-line or configuration option (for example `-enable3way` or `-HandshakeMode:3way`). Unless the option is explicitly provided, the current START-based discovery behavior must remain unchanged.
+
+Summary of required changes
+
+- Add an option to send a headered `SYN` control frame when the new 3‑way handshake is enabled; do not change existing START sends when the option is not enabled.
+- Add encoder/decoder helpers for the SYN / SYN-ACK / ACK control frames and integrate them into the existing headered datagram parsing flow.
+- Update receiver parsing to recognize the new control flags (`0x0100`, `0x0101`, `0x0102`) and to perform handshake state transitions (allocate/assign ConnectionId, flush dedup caches, etc.).
+- Ensure connection-id datagram (`0x1000`) remains supported and add guidance for the responder to send its connection-id immediately after `SYN-ACK` if it begins sending media prior to receiving `ACK`.
+- Add a backward-compatibility configuration option to accept legacy 5-byte `START` payloads if desired.
+
+High-level migration steps (recommended order)
+
+1. Add ProtocolFlag constants and control-frame helpers
+   - Files: `ctsMediaStreamProtocol.hpp`
+   - Actions:
+    - Define new ProtocolFlag constants (e.g., `c_udpDatagramFlagSyn = 0x0100`, `c_udpDatagramFlagSynAck = 0x0101`, `c_udpDatagramFlagAck = 0x0102`).
+      - Implemented in: `ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.hpp` (constants present).
+    - Add fixed sizes and helper prototypes for control frames (encoder/decoder) in the header file.
+      - Implemented in: `ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.hpp` (control lengths and prototypes present).
+    - Add `MakeSynTask`, `MakeSynAckTask`, `MakeAckTask` functions similar in shape to `MakeConnectionIdTask` but which produce headered datagrams (26-byte header + control body).
+      - Implemented in: `ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.cpp` (functions `MakeSynTask`, `MakeSynAckTask`, `MakeAckTask`).
+    - Add `ParseControlFrame` helper to validate control frame payloads and extract fields (Version, Flags, 37-byte connection id, optional TLVs).
+      - Implemented in: `ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.cpp` (`ParseControlFrame` present).
+    - Status: COMPLETE (constants, helpers, and implementations added).
+
+2. Add control frame implementations
+   - Files: `ctsMediaStreamProtocol.hpp` (inline small helpers) or new `ctsMediaStreamProtocol.cpp` if preferred for implementation code.
+   - Actions:
+     - Implement `MakeSynTask`/`MakeSynAckTask`/`MakeAckTask` to populate a `ctsTask` that will be queued on the socket sending path. These should set the ProtocolFlag in the first 2 bytes and follow the 26-byte header layout for headered datagrams. For control frames SequenceNumber/QPC/QPF SHOULD be zero.
+       - Implementations found in `ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.cpp`.
+     - Implement `ParseControlFrame` to run during receive parsing when ProtocolFlag is a control value.
+       - Implemented in `ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.cpp`.
+     - Status: COMPLETE (control frame encode/decode implemented).
+
+3. Update send-side code to use SYN when enabled; otherwise preserve START behavior
+  - Files: `ctsIOPatternMediaStream.cpp`, potentially other IO pattern or client-init code that sends `START`.
+   - Locations:
+     - `ctsIOPatternMediaStream.cpp` — replace `c_startBuffer[] = "START"` and its `resendTask` / Send logic with calls to produce a `SYN` control task (using `MakeSynTask`).
+     - Any other call-sites that construct a task with `g_udpDatagramStartString` or `MediaStreamAction::START` (see `ctsMediaStreamProtocol.hpp`) should be updated to build a SYN headered frame instead.
+   - Actions:
+     - When the 3‑way handshake mode is enabled (via CLI/config), replace send of the 5-byte payload with an enqueued headered `SYN` task. When disabled, preserve the existing `START` send logic.
+       - Implemented: `ctsTraffic/ctsTraffic/ctsIOPatternMediaStream.cpp` — `StartCallback` checks `ctsConfig::IsMediaStream3WayEnabled()` and sends a SYN via `ctsMediaStreamMessage::MakeSynTask` when enabled; otherwise it sends the legacy 5-byte `START` payload.
+     - Ensure retransmission/backoff logic is preserved and applies to whichever discovery mechanism is active (legacy START or 3‑way SYN).
+       - Partially implemented: timer/backoff logic reuses `SetNextStartTimer()` for both START and SYN retransmits in `ctsIOPatternMediaStream.cpp`.
+     - Status: COMPLETE for send-side switching; retransmit/backoff behavior appears preserved.
+
+4. Update receive-side parsing and handshake state machine
+   - Files: `ctsMediaStreamProtocol.hpp`, `ctsIOPatternMediaStream.cpp`, `ctsIOPattern.cpp`, `ctsSocketBroker.cpp`/`ctsSocket.cpp` (where inbound datagrams are parsed/handled).
+   - Locations and functions to update (based on grep results):
+     - `ctsMediaStreamProtocol.hpp` — function(s): `ValidateBufferLengthFromTask`, `GetSequenceNumberFromTask`, `MakeConnectionIdTask`, `GetConnectionIdFromTask`, and the switch that handles `MediaStreamAction::START`.
+     - `ctsIOPatternMediaStream.cpp` — where tasks are created/received and where `ctsMediaStreamMessage::SetConnectionIdFromTask` and `GetSequenceNumberFromTask` are used.
+     - Receiver code that currently checks for the 5-byte `START` token (search results: `ctsMediaStreamProtocol.hpp` lines that compare `inputBuffer` to `g_udpDatagramStartString`, and `ctsIOPatternMediaStream.cpp` where `c_startBuffer` is used). Replace these checks with logic that:
+       - Parses the 2-byte ProtocolFlag at offset 0 for incoming datagrams and uses the headered datagram logic order (connection-id versus headered datagram).
+       - If ProtocolFlag denotes a control frame (`0x0100`..`0x0102`), invoke `ParseControlFrame` and handle handshake state transitions: when `SYN` arrives, generate/send `SYN-ACK`; when `SYN-ACK` arrives, generate/send `ACK`; when `ACK` arrives, bind the tuple to the connection-id and flush dedup caches as specified.
+   - Actions:
+     - Implement a small handshake state table per tuple (or reuse existing session mapping structures) to track whether `SYN` received/sent, `SYN-ACK` sent/received, and `ACK` confirmed.
+       - Implemented: `ctsTraffic/ctsTraffic/ctsMediaStreamReceiver.cpp` declares `g_handshakeMap` and `g_handshakeMapMutex` and updates `HandshakeInfo` on SYN reception (records `SynReceived`, `lastUpdate`, and assigns an `assignedConnectionId`).
+     - Ensure reassembly/deduplication caches are flushed when connection-id changes or handshake completes per new rules.
+       - Implemented on client (receiver) side: `ctsIOPatternMediaStream.cpp` in `CompleteTaskBackToPattern` flushes local dedup/reassembly frame entries when receiving `SYN-ACK` and assigns the connection id to the receiver's local identifier.
+     - Add handling to accept connection-id datagrams and map them to tuple state.
+       - Partial: `ctsMediaStreamMessage::ValidateBufferLengthFromTask` and `GetProtocolHeaderFromTask` support `c_udpDatagramProtocolHeaderFlagId` (connection-id), and `ctsIOPatternMediaStreamReceiver::CompleteTaskBackToPattern` handles ProtocolFlagId by calling `SetConnectionIdFromTask`. The receiver-side mapping of connection-id datagrams to handshake state is partially implemented (client saves connection id on receipt).
+     - Status: PARTIALLY COMPLETE — SYN/SYN-ACK/ACK parsing and basic handshake state storage present on server and client sides; full tuple binding and ACK processing to finalize mapping is implemented in parts (Responder sends SYN-ACK and Initiator sends ACK in `ctsIOPatternMediaStream.cpp` on SYN-ACK receipt). More integration/testing recommended.
+
+5. Expose handshake mode and legacy START handling via CLI/config
+  - Files: `ctsConfig.h` / `ctsConfig.cpp` (or wherever runtime flags/config live). Add a command-line/config option such as `-enable3way` (default: `false`) or a mode switch `-HandshakeMode={legacy|3way}`.
+   - Actions:
+     - If `-enable3way` (or `-HandshakeMode=3way`) is provided, enable the 3‑way handshake behavior and treat SYN/SYN-ACK/ACK control frames as described here.
+       - Implemented flag: `ctsConfig::ctsConfigSettings::EnableMediaStream3WayHandshake` (default false) and accessor `ctsConfig::IsMediaStream3WayEnabled()` implemented in `ctsTraffic/ctsTraffic/ctsConfig.cpp` and `ctsTraffic/ctsTraffic/ctsConfig.h`.
+     - If the option is not provided (default), retain the legacy START-based discovery behavior unchanged.
+       - Verified: default remains legacy START; send/receive code checks `IsMediaStream3WayEnabled()` to choose behavior.
+     - Optionally provide `AllowLegacyStart` as a separate flag when running in 3‑way mode to accept legacy START from peers for migration interoperability.
+       - Not implemented: no explicit `AllowLegacyStart` option found; legacy START acceptance is preserved by default when 3-way is disabled.
+     - Status: PARTIAL (feature-gate present; CLI parsing to set it not yet visible — recommend adding command-line parsing to set `EnableMediaStream3WayHandshake`).
+
+6. Update send-path when responder accepts SYN
+   - Files: `ctsIOPatternMediaStream.cpp`, `ctsIOPattern.cpp` (task creation/send path)
+   - Actions:
+     - When Responder accepts a SYN (i.e., sends `SYN-ACK` with Accept=1 and AssignedConnectionId), ensure Responder sends a `connection-id` datagram (`0x1000`) as first datagram after `SYN-ACK` if it intends to start sending media immediately prior to receiving the `ACK`.
+     - Alternatively, embed connection-id in a small control TLV in media datagrams if you prefer; update senders/receivers accordingly.
+
+7. Update tests and unit tests
+   - Files: MSTest tests referencing behavior around START, discovery, or connection-id. Update or add tests to cover:
+     - SYN / SYN-ACK / ACK encoding/decoding round-trip.
+     - Legacy START acceptance only when the new config flag is enabled.
+     - Deduplication cache flush behavior when connection-id changes.
+     - Responder optimistic start (SYN-ACK + connection-id + media before ACK) scenarios.
+
+8. Documentation and release notes
+   - Files: `documents/media_streaming_protocol_spec_3way.md`, `README.md` — add migration notes and instructions for operators to enable legacy START acceptance during transition.
+
+Targeted files and functions (concrete list)
+
+- ctsTraffic/ctsTraffic/ctsMediaStreamProtocol.hpp
+  - Add: ProtocolFlag constants (`c_udpDatagramFlagSyn`, `c_udpDatagramFlagSynAck`, `c_udpDatagramFlagAck`).
+  - Add: `MakeSynTask`, `MakeSynAckTask`, `MakeAckTask`, `ParseControlFrame` prototypes and inline helpers for payload sizes.
+  - Update: Remove or keep behind flag the existing `g_udpDatagramStartString` and `MediaStreamAction::START` handling. Update `ValidateBufferLengthFromTask` pathing and any `START` switch cases.
+  - Keep/adjust: `MakeConnectionIdTask`, `SetConnectionIdFromTask`, `GetSequenceNumberFromTask` to interoperate with control frames.
+
+- ctsTraffic/ctsTraffic/ctsIOPatternMediaStream.cpp
+  - Replace `c_startBuffer[] = "START"` send logic with constructing and sending `SYN` control frame using `MakeSynTask`.
+  - Update resend and backoff logic to operate on SYN tasks.
+  - Update receive-path logic that previously expected the 5-byte START to now initiate handshake state machine on SYN.
+
+- ctsTraffic/ctsTraffic/ctsIOPattern.cpp
+  - Verify and update cases that create/expect `UdpConnectionId` tasks (send/recv) so they accept connection-id datagram interactions in handshake sequences.
+
+- ctsTraffic/ctsTraffic/ctsSocket*.cpp (where incoming datagrams are parsed)
+  - Identify the function(s) that parse raw UDP datagrams and route them to higher-level handlers. Update the parsing order: connection-id check (`0x1000`) -> headered datagram parse -> control frame handling if ProtocolFlag in control range -> legacy START only if `AllowLegacyStart`.
+
+- ctsTraffic/ctsTraffic/ctsIOPatternMediaStreamReceiver logic
+  - Update logic that uses `GetSequenceNumberFromTask` and `SetConnectionIdFromTask` to remain compatible when media arrives before handshake completion. Use connection-id mapping to disambiguate sessions.
+
+- ctsTraffic/ctsTraffic/ctsIOPatternRateLimitPolicy.hpp (as needed)
+  - No direct protocol changes expected, but verify any behavior that starts sending only after START must be updated to work with handshake semantics.
+
+- ctsTraffic/ctsTraffic/ctsConfig.*
+  - Add configuration option `AllowLegacyStart` and possibly handshake timeouts, retransmit/backoff parameters.
+
+- Unit Tests (MSTest)
+  - Update or add tests under `MSTest/` to verify handshake encode/decode and receive/send behavior.
+
+Detailed implementation notes and guidance
+
+- Control frame layout and framing
+  - Control frames are headered datagrams and must include the 26-byte header. For control frames SequenceNumber/QPC/QPF MAY be zero.
+  - Control body fixed prefix: Version (1 byte), Flags (1 byte), Reserved (2 bytes), 37-byte connection id string, optional TLVs. TLV usage should follow existing reserved-extension guidance.
+
+- Parsing order
+  - On receive, check datagram length >= 2 then read ProtocolFlag.
+  - If ProtocolFlag == `0x1000`, treat as connection-id (37 byte payload) and map to tuple.
+  - Else if ProtocolFlag is headered data flag or control flags (`0x0000`, `0x0001`, `0x0100`..`0x0102`), ensure datagram length >= 26 and parse header fields.
+  - If ProtocolFlag in `0x0100..0x0102`, invoke handshake parsing and state transitions.
+  - Only if configured to allow the legacy discovery token should the receiver also accept an exact-length (5-byte) `START` payload prior to headered parsing.
+
+- Handshake state storage
+  - Add a small per-tuple handshake state entry (in the existing tuple-to-session map) recording: `state` (none, syn-sent, syn-received, synack-sent, established), `assigned_connection_id`, `last_syn_time`, retransmit/backoff info.
+  - When `SYN` is received for a tuple with no active session, the Responder should decide to accept or reject and send back a `SYN-ACK` with `AssignedConnectionId`. The Responder should set the tuple-to-connection-id mapping when it either accepts and/or receives the `ACK`.
+
+- Deduplication flush
+  - When a new connection-id is associated with a tuple (either because the Responder assigns one or an incoming connection-id datagram changes it), flush deduplication and reassembly caches for that tuple. If you already key caches by connection-id when available, this can be a simple mapping change.
+
+- Optimistic start
+  - If the Responder wishes to begin streaming immediately after sending `SYN-ACK`, it MUST include an explicit connection-id datagram as the first datagram after `SYN-ACK` (or embed the connection-id in media datagrams via a small TLV). Receivers must use that connection-id information (rather than tuple alone) to map incoming media to session state.
+
+Testing checklist
+
+- Unit tests:
+  - Round-trip encode/decode for SYN, SYN-ACK, ACK control frames.
+  - Parser tests: headered datagram parse including fragmentation flag and control flags.
+  - Legacy acceptance test: legacy START accepted only when config enabled.
+  - Deduplication flush tests: confirm that changing connection-id or completing handshake flushes prior dedup state.
+
+- Integration tests:
+  - End-to-end handshake: Initiator sends SYN, Responder replies SYN-ACK + connection-id, Initiator sends ACK; confirm session established and media flows.
+  - Optimistic start: Responder sends SYN-ACK and connection-id and begins sending media before ACK; Initiator accepts media when connection-id arrives and/or ACK completed.
+  - Retransmission/backoff: simulate lost handshake packets and ensure proper retransmit/backoff behaviour.
+
+Rollout / compatibility guidance
+
+- Add the new handshake behavior behind a feature gate (command-line/config option). The default behavior must preserve the legacy START-based discovery to avoid surprising existing deployments.
+- Recommended migration approach: enable the 3‑way handshake via the CLI option on a controlled set of hosts (canaries) and verify interoperability. Use an `AllowLegacyStart` compatibility option while rolling out so mixed deployments can interoperate during transition.
+- Document the change in release notes and in `README.md` with clear instructions for the CLI option to enable 3‑way mode and for the compatibility flag to accept legacy START during migration.
+
+Estimated effort
+
+- Small change (1–2 days): add constants and encoder/decoder helpers, update `ctsIOPatternMediaStream.cpp` to send SYN, and update receive parsing to route control frames to a simple handshake handler.
+- Medium (2–4 days): add state-tracking, thorough tests, and integrate optimistic-start behavior robustly.
+- Larger (4+ days): if you want to embed connection-id TLVs directly into media datagrams (requires header extensions), or if the codebase requires refactoring to centralize parsing, expect more time.
+
+If you want, I can:
+- Produce a targeted patch (PR) that implements the constants, helper functions, and wires the 3‑way behavior to a CLI/config option so sends are switched only when enabled.
+- Add unit tests that verify frame encoding/decoding and simple handshake flow, including tests that confirm legacy START remains active by default and that 3‑way mode is opt-in.
+
+Tell me whether you prefer a minimal incremental patch (add flags + change sends only when enabled, add decoder stubs) or a complete implementation (helpers + handshake state + tests) and I will implement it next.
+
+Instructions for Copilot:
+1) Make small, incremental, minimal changes to implement the changes documented here.
+2) Make the changes backwards compatible, keeping the existing behavior while adding new behavior under a runtime flag.
+3) Some parts of this have already been implemented, so always check if the proposed functionality is present before implementing it.
+4) Ensure that the existing behavior continues to work after each step.
+5) build and check that the build succeeds.
+6) run the test (run the one with -listen: in the background)
+Server:
+```
+x64\Debug\ctsTraffic.exe -listen:* -protocol:udp -bitspersecond:1000000 -FrameRate:1000 -StreamLength:5 -ConsoleVerbosity:1 -verify:connection -serverexitlimit:50
+```
+Client:
+```
+x64\Debug\ctsTraffic.exe -target:localhost -protocol:udp -bitspersecond:1000000 -FrameRate:1000 -StreamLength:5 -ConsoleVerbosity:1 -verify:connection -connections:50 -iterations:1
+```
+1) After all the changes pass tests, stop and let me review.

--- a/documents/media_streaming_protocol_spec.md
+++ b/documents/media_streaming_protocol_spec.md
@@ -1,0 +1,283 @@
+
+Media Streaming Protocol — Conformance Specification
+
+Status: Informational
+
+Abstract
+
+This document specifies a minimal, precise, and implementation-independent protocol for discovery and media delivery over UDP datagrams. It prescribes on-wire datagram layouts, parsing and validation rules, sender and receiver behaviors, fragmentation semantics, timing fields, and error handling that an implementation MUST follow to be conformant. The specification intentionally avoids platform or source-code references.
+
+1. Terminology
+
+- Initiator: the endpoint that requests a stream from a Responder (typically the receiver).
+- Responder: the endpoint that supplies media data to an Initiator (typically the sender).
+- Datagram: a single UDP packet delivered as an atomic unit.
+- Packet tuple: (source IP, source port, destination IP, destination port) used to identify a logical session.
+- Sequence Number: unsigned 64-bit integer carried in the header and used for ordering and deduplication.
+- QPC: unsigned 64-bit sender timestamp captured from a high-resolution clock at send time.
+- QPF: unsigned 64-bit frequency value representing clock ticks per second for the clock used to capture QPC.
+- Headered Datagram: a datagram that begins with the fixed protocol header defined in section 3 followed by application payload bytes.
+- Discovery Datagram: a 5-byte UDP payload containing the ASCII token "START" used to request a stream.
+
+2. Design Goals
+
+- Simplicity: minimal on-wire state for discovery, simple header layout for timing and ordering.
+- Interoperability: precise byte offsets and field sizes to allow independent implementations to interoperate.
+- Defensive parsing: clear validation rules preventing ambiguous parsing between discovery and headered datagrams.
+- Stateless discovery: discovery is one-way and does not require an acknowledgement to begin streaming.
+
+3. Byte Order and Encoding
+
+All multi-byte integer fields in this protocol MUST be transmitted using little-endian byte order. Implementations MUST parse and generate fields using little-endian encoding; no alternate endianness is permitted for interoperable implementations.
+
+4. Datagram Types
+
+An implementation MUST recognize the following datagram forms and disambiguate them exactly as specified:
+
+- Discovery Datagram: payload length == 5 bytes and payload equals ASCII "START" (0x53 0x54 0x41 0x52 0x54). This form contains no protocol header and is strictly the five bytes only.
+- Headered Datagram (standard data): begins with the 26-byte protocol header (section 5) followed by payload bytes.
+- Connection-id Datagram: a control datagram consisting of a 2-byte ProtocolFlag value (0x1000) followed immediately by a NUL-terminated connection identifier string (37 bytes canonical). This form is NOT the same as a headered datagram and does NOT include the 26-byte data header. See section 7 for exact rules.
+
+Implementations MUST first test for discovery datagrams (exact-length and exact-content) and the connection-id minimal form before attempting to parse the 26-byte headered format. Order of checks is: discovery (5 bytes), connection-id (>=39 bytes with ProtocolFlag==0x1000), then headered datagram (>=26 bytes with ProtocolFlag==0x0000 or ProtocolFlag==0x0001).
+
+
+5. Header Layout (on-wire)
+
+Headered Datagrams use the following fixed on-wire byte layout (offsets are zero-based):
+
+- ProtocolFlag: 2 bytes, offset 0
+- SequenceNumber: 8 bytes, offset 2
+- QPC: 8 bytes, offset 10
+- QPF: 8 bytes, offset 18
+- Payload: variable, offset 26
+
+Total fixed header length: 26 bytes.
+
+Field descriptions:
+
+ - ProtocolFlag (2 bytes): unsigned 16-bit value distinguishing datagram subtypes within the headered format. For headered datagrams this field MUST be one of the following values:
+  - 0x0000 — Standard data/control datagram with no fragmentation metadata.
+  - 0x0001 — Standard data/control datagram with the Fragmentation flag set; a 16-byte Fragment Metadata block MUST follow the fixed header.
+
+  Implementations MUST reject headered datagrams whose ProtocolFlag is any value other than 0x0000 or 0x0001 and MUST record a validation error when such datagrams are received.
+
+- SequenceNumber (8 bytes): unsigned 64-bit integer assigned once per logical send. All fragments produced while partitioning the logical buffer MUST use the same SequenceNumber.
+
+- QPC (8 bytes): unsigned 64-bit clock sample captured by the sender at or immediately prior to transmit of the datagram. Interpreted with QPF.
+
+- QPF (8 bytes): unsigned 64-bit ticks-per-second value to convert QPC into elapsed time.
+
+
+6. Sequence Assignment and Fragmentation Semantics
+
+- Sequence number granularity: The sender MUST allocate a single SequenceNumber for each logical send (logical buffer). All fragments produced while partitioning that logical buffer MUST carry the same SequenceNumber.
+
+- Fragment composition (extension): To enable unambiguous reassembly, this specification defines an optional per-fragment metadata block that immediately follows the 26-byte header when the sender sets the Fragmentation flag described below. The base header alone does not contain fragment positioning metadata; therefore, senders MUST choose one of the following strategies and advertise/implement it consistently:
+  - Inline Fragment Metadata (recommended, normative): The sender MUST set bit 0x0001 in the ProtocolFlag (i.e., ProtocolFlag & 0x0001 != 0) to indicate that a 16-byte Fragment Metadata block follows the fixed 26-byte header. The metadata block layout (little-endian) is:
+    - FragmentOffset: 8 bytes (unsigned 64-bit) — byte offset of this fragment's payload within the original logical buffer.
+    - TotalLength: 8 bytes (unsigned 64-bit) — total byte length of the original logical buffer.
+    The application payload begins immediately after the Fragment Metadata block at offset 42 (26 + 16).
+
+  - Out-of-Band Reassembly (alternate): If a sender does NOT set the fragmentation flag (bit 0x0001 is clear), the sender MUST ensure each logical buffer fits within a single datagram and therefore no reassembly is necessary. Implementations that choose this strategy MUST document the maximum logical buffer size they support (see section 12 for limits).
+
+- Header per fragment: Every fragment sent as a headered datagram MUST include the full 26-byte header. If the fragmentation flag is set, the 16-byte Fragment Metadata block MUST immediately follow the header and precede the fragment payload.
+
+- QPC/QPF and fragments: QPC is captured per-fragment and MAY differ between fragments that share a SequenceNumber. QPF MAY remain constant for the logical send.
+
+ - Logical timestamp selection (normative): To avoid ambiguity and inconsistent playback jitter, the sender SHOULD populate QPC in each fragment with a per-fragment capture timestamp but the receiver MUST use the QPC value from the fragment whose FragmentOffset == 0 (the fragment that contains the first byte of the logical buffer) as the canonical "logical timestamp" for the reassembled logical buffer. If the sender elects not to include fragmentation metadata (i.e., each logical send fits in one datagram), the receiver uses the only fragment's QPC as the logical timestamp.
+
+- Minimum payload per fragment: The sender MUST ensure no transmitted fragment contains zero payload bytes. When fragmentation metadata is included, the sender MUST account for the additional 16 bytes when calculating fragment payload sizes.
+
+- Logical send size restriction: A logical send whose total size is less than or equal to the fixed header length (or header plus fragment metadata when the fragmentation flag is set) MUST be rejected by the sender.
+
+
+7. Connection-id Datagram (control)
+
+- Format: The connection-id datagram is a minimal control datagram and is NOT a headered data datagram. Its on-wire layout is:
+  - ProtocolFlag: 2 bytes (value 0x1000) at offset 0
+  - ConnectionIdString: 37 bytes at offsets 2..38 inclusive — canonical form is a 36-character UUID ASCII string followed by a NUL (0x00) terminator.
+
+- Minimum length: Receivers MUST validate that a connection-id datagram has length >= 39 bytes (2 + 37) before attempting extraction.
+
+- Extraction: Receivers MUST copy the first 37 bytes immediately following the ProtocolFlag and treat them as the NUL-terminated connection id string. Any trailing bytes beyond the 37-byte canonical field MAY be ignored.
+
+- Semantics/Purpose: Connection-id datagrams provide an explicit, minimal control mechanism to associate a packet tuple with an opaque connection identifier used for correlation, logging, or out-of-band telemetry. Typical approved uses:
+  - Responder sends a connection-id to the Initiator shortly after accepting a discovery request to provide a stable identifier for the stream.
+  - Either endpoint may send a connection-id as a control message to update or reassign the identifier for a tuple when practical.
+  - Receivers use the connection id to correlate metrics, logs, and to map incoming packets to higher-level session state when tuple- or port-based correlation is insufficient.
+
+Implementations MUST NOT assume connection-id datagrams imply the presence of a 26-byte header or of sequence/telemetry fields; the two forms are disjoint by design.
+
+ - Validation and treatment: Receivers MUST treat the connection-id field as an opaque identifier for correlation. Receivers MAY perform optional syntax validation (for example, validate the 36-byte portion matches conventional UUID textual syntax with hyphens) for diagnostics or policy enforcement, but MUST NOT reject or drop the datagram solely because the identifier does not parse as a UUID. Implementations MUST accept any 37-byte NUL-terminated string as a valid connection id for mapping and correlation purposes.
+
+ - Session semantics: A change in the observed connection-id for a packet tuple SHOULD be interpreted as a session re-identification for that tuple. Receivers MUST treat different connection-id values as distinct logical sessions even when the 4-tuple is identical.
+
+ - Security note: Connection-id values are supplied by remote endpoints and can be adversarially controlled. Receivers MUST NOT treat connection-id values as secrets or use them for access control decisions.
+
+
+8. Discovery Procedure
+
+- Initiator behavior: To request a stream, the Initiator MUST send a single UDP datagram whose entire payload is the ASCII string "START" (5 bytes). The discovery datagram MUST contain no header and MUST be exactly five bytes long.
+
+- Responder behavior: Upon receipt of a datagram whose length equals exactly five bytes and contents equal the ASCII string "START", the Responder MUST treat the packet tuple as a request to start a stream. The Responder MAY allocate resources and, if resources are available, begin transmitting headered datagrams to the Initiator's tuple.
+
+- Retransmission: The Initiator MAY retransmit the discovery datagram periodically while waiting for media; retransmissions are identical 5-byte payloads.
+
+- Disambiguation priority: Implementations MUST test for discovery datagrams first (exact-length + exact-content) to avoid ambiguous parsing.
+
+
+9. Packet Reception and Validation
+
+When a receiver receives a UDP datagram it MUST perform these checks in order:
+
+1. If datagram length == 5, compare payload to ASCII "START". If equal, process as discovery (section 8) and stop further parsing.
+2. If datagram length < 2, drop and record a validation error.
+3. Read the 2-byte ProtocolFlag at offset 0 (little-endian).
+  - If ProtocolFlag == 0x1000 (connection-id): verify datagram length >= 39; if shorter, drop and record a validation error. Otherwise extract the first 37 bytes after the ProtocolFlag as the NUL-terminated connection id string and process it (section 7).
+  - Else if ProtocolFlag == 0x0000 or ProtocolFlag == 0x0001 (i.e., valid headered data frames with optional fragmentation flag): verify datagram length >= 26; if shorter, drop and record a validation error. Then parse the header fields as below.
+  - Otherwise: treat ProtocolFlag as unknown, drop datagram and record a validation error.
+4. For headered datagrams: parse SequenceNumber (offset 2), QPC (offset 10), QPF (offset 18) as unsigned little-endian integers. Determine whether the fragmentation flag is set (ProtocolFlag bit 0x0001). If set, verify datagram length >= 42 (26 + 16) and parse the 16-byte Fragment Metadata block: FragmentOffset (8 bytes) and TotalLength (8 bytes). The application payload begins at offset 26 (no-fragmentation) or 42 (with fragment metadata) and has length (datagram length − payload_offset).
+5. All parsed fields MUST be validated as untrusted input before use.
+
+Receivers MUST not rely on any implicit bufferOffset; all offsets in this specification are absolute within the datagram payload as received from the transport.
+
+
+10. Ordering, Deduplication, and Reassembly
+
+- Ordering: Receivers MUST use SequenceNumber to place logical sends in order. SequenceNumber identifies a logical send (which may be carried by one or more fragments). Implementations MAY use a bounded reordering buffer or sliding window to tolerate out-of-order delivery.
+
+- Deduplication: Receivers MUST detect and discard datagrams whose SequenceNumber indicates the logical send has already been accepted and processed. Implementations SHOULD maintain a bounded recent-sequence cache keyed by packet tuple and SequenceNumber.
+
+- Reassembly (normative when fragmentation metadata used): When the sender indicates fragmentation (ProtocolFlag bit 0x0001), each fragment includes FragmentOffset and TotalLength. The receiver MUST:
+  - Allocate or map a reassembly buffer sized to TotalLength (subject to buffer limits, section 12).
+  - Place the fragment payload at FragmentOffset within the reassembly buffer.
+  - Mark the byte-range [FragmentOffset, FragmentOffset + fragment_payload_length) as received.
+  - When the union of received ranges equals TotalLength, the logical buffer is complete; the receiver MUST then present the reassembled logical buffer to the application and release reassembly state for the SequenceNumber.
+  - If overlapping fragments are received, the receiver MUST accept the first-arriving bytes for each position and ignore overwrites from later duplicates for deduplication purposes.
+
+- Reassembly without fragmentation metadata: If the sender elects the Out-of-Band Reassembly strategy (i.e., it does not set the fragmentation flag and ensures logical sends are single-datagram), the receiver MUST treat each headered datagram as a complete logical send and no reassembly is required.
+
+- Missing fragment handling: The receiver MUST implement a reassembly timeout (section 12). If a logical send is incomplete when the timeout expires, the receiver MUST discard partial reassembly state for that SequenceNumber and record a validation/timeout metric.
+
+
+11. Timing Fields and Interpretation
+
+- QPC and QPF are diagnostic fields for telemetry and timing calculations. QPC is an unsigned 64-bit clock sample captured by the sender at transmit time; QPF is an unsigned 64-bit ticks-per-second value for that clock.
+
+- Receivers MUST convert QPC to elapsed time using QPF as the divisor. Example for milliseconds: elapsed_ms = (QPC * 1000) / QPF. Implementations MUST use integer arithmetic that accounts for 64-bit values and avoid overflow by applying appropriate scaling.
+
+- QPC/QPF are NOT security mechanisms and MUST NOT be used for authentication or replay protection.
+
+- Implementations MUST handle wraparound per unsigned 64-bit arithmetic semantics; however, wraparound is expected to be rare in practical runtimes.
+
+
+12. Limits, Timeouts, Error Handling and Telemetry
+
+- Maximum datagram size: The on-wire maximum UDP payload an implementation MUST accept is 65507 bytes (IPv4/IPv6 maximums accounting for headers). Senders MUST NOT transmit datagrams with a payload larger than 65507 bytes. Implementations SHOULD use a conservative default maximum transmit payload (for example 1200 bytes) unless Path MTU discovery has validated larger payloads are safe.
+
+ - Fragmentation payload calculation: When the fragmentation metadata block is used, the sender MUST compute the per-fragment application payload capacity as:
+
+   FragmentPayloadSize = MTU - IP_Overhead - UDP_Overhead - HeaderLength - FragMetadataLength
+
+   Where:
+   - `MTU` is the local path MTU in bytes for the link (RECOMMENDED default 1500 bytes on Ethernet).
+   - `IP_Overhead` is the IP header size (commonly 20 bytes for IPv4 without options; 40 bytes for IPv6 without extension headers).
+   - `UDP_Overhead` is 8 bytes.
+   - `HeaderLength` is 26 bytes (protocol header length).
+   - `FragMetadataLength` is 16 bytes when fragmentation metadata is present, otherwise 0.
+
+   Example (IPv4 conservative default): for MTU=1500, IP_Overhead=20, UDP_Overhead=8, HeaderLength=26, FragMetadataLength=16:
+
+   FragmentPayloadSize = 1500 - 20 - 8 - 26 - 16 = 1430 bytes
+
+   Implementations should take care to compute the fragment payload size using the actual MTU and header sizes on the path when possible.
+
+- Reassembly buffer limits: To prevent resource exhaustion, receivers MUST enforce a per-sequence maximum reassembly buffer size (RECOMMENDED default 16 MiB) and a global maximum concurrent reassembly memory budget (RECOMMENDED default 64 MiB). If allocating a reassembly buffer would exceed these limits, the receiver MUST reject the reassembly attempt and record a resource-exhaustion metric.
+
+- Reassembly timeout: Receivers MUST abort and discard incomplete reassembly state for a SequenceNumber if it remains incomplete for more than a configurable timeout (RECOMMENDED default 5000 ms). The receiver MUST record a timeout metric when this occurs.
+
+- Unknown or invalid ProtocolFlag: Drop datagram and increment validation error metrics.
+
+- Short header or malformed datagram: Drop datagram, increment validation error metric, and do not attempt reassembly.
+
+- Duplicate datagrams: Detect by SequenceNumber and tuple and increment duplicate metric when duplicates are observed. Duplicate fragments that do not provide new byte ranges are ignored.
+
+ - Deduplication cache and session restarts: Because senders may restart and reuse SequenceNumber ranges, implementations MUST adopt logic to avoid false-positive deduplication across distinct logical sessions. Receivers MUST flush or reset deduplication state for a packet tuple when either:
+   - A discovery `START` datagram is received for the tuple, or
+   - A connection-id datagram is received for the tuple with a connection-id value different from the current one associated with that tuple.
+
+   Implementations SHOULD include the connection-id in the deduplication key when available (i.e., key = (tuple, connection-id, SequenceNumber)). If the connection-id is unknown, fall back to (tuple, SequenceNumber) but follow the flush rules above when a new connection-id or START token is observed.
+
+- Telemetry: Implementations SHOULD record metrics for received bytes, received datagrams, validation errors, duplicate frames, sequence gaps, reassembly timeouts, and resource rejections.
+
+
+13. Security Considerations
+
+- This protocol provides no confidentiality, integrity, or replay protection. Implementations that require those properties MUST layer appropriate transport- or application-layer protections (e.g., DTLS, IPsec, or application-level authenticated encryption).
+
+- Receivers MUST validate all input sizes and bounds before using them to index memory or allocate resources and MUST enforce reassembly limits (section 12) to avoid denial-of-service via large or fragmented logical sends.
+
+
+14. Configuration Parameters (Local Only)
+
+The following settings are local to each implementation and are NOT carried or negotiated on the wire:
+
+- `bitspersecond`: target transmit rate in bits per second.
+- `framerate`: logical frames produced per second.
+- `streamlength`: duration in seconds for a stream.
+
+Senders use these parameters to determine frame sizes and pacing. Tests and interoperable deployments MUST coordinate these parameters out-of-band.
+
+
+15. Interoperability Recommendations
+
+- This specification mandates little-endian encoding for all multi-byte fields to avoid coordination problems. Implementations MUST comply.
+
+- To reduce fragmentation overhead and improve robustness across diverse networks, prefer conservative default datagram sizes (e.g., 1200 bytes) and use Path MTU discovery before sending larger payloads.
+
+- When extending this protocol, use reserved ProtocolFlag values and document extensions clearly; deploy only when both endpoints agree to the extension.
+
+
+16. Examples
+
+- Discovery: Initiator sends a single UDP datagram with payload bytes [0x53,0x54,0x41,0x52,0x54] (ASCII "START"). Responder validates length == 5 and exact content match, then may begin streaming.
+
+- Connection-id: Responder sends ProtocolFlag 0x1000 followed by a 37-byte connection id: [0x00 0x10] + ASCII UUID + 0x00. Receiver extracts the 37 bytes after the flag as the connection id string.
+
+- Headered datagram (no fragmentation metadata):
+  - ProtocolFlag (0x0000) => bytes 00 00
+  - SequenceNumber (0x0000000000000005) => bytes 05 00 00 00 00 00 00 00
+  - QPC (example) => eight little-endian bytes
+  - QPF (example) => eight little-endian bytes
+  - Payload bytes follow at offset 26.
+
+- Headered datagram (with fragmentation metadata):
+  - ProtocolFlag with fragmentation bit set (0x0001) => bytes 01 00
+  - SequenceNumber => 8 bytes
+  - QPC => 8 bytes
+  - QPF => 8 bytes
+  - FragmentOffset => 8 bytes
+  - TotalLength => 8 bytes
+  - Payload begins at offset 42.
+
+
+17. Conformance Tests (suggested)
+
+- Round-trip serialization test: serialize header fields and (when used) fragmentation metadata at specified offsets and verify parsing yields identical values.
+- Discovery recognition test: verify datagrams length 5 with payload "START" are treated as discovery; datagrams length 6 beginning with "START" are not.
+- Connection-id test: verify datagrams with ProtocolFlag==0x1000 and length >=39 yield correct 37-byte connection id extraction.
+- Header length validation test: verify headered datagrams shorter than 26 bytes are rejected.
+- Fragmentation and reassembly tests: verify that when the fragmentation flag is set, fragments can be reassembled using FragmentOffset and TotalLength; verify timeouts and buffer limits are enforced.
+- Sequence monotonicity: verify sender increments SequenceNumber once per logical send and that receivers observe monotonic increases.
+
+- Logical timestamp test: verify that when a logical buffer is fragmented, the receiver uses the QPC value from the fragment whose FragmentOffset == 0 as the canonical logical timestamp for the reassembled buffer.
+- Deduplication flush test: verify the receiver flushes deduplication state for a tuple when it receives a `START` datagram or a connection-id datagram with a different connection-id, allowing a restarted sender that reuses SequenceNumbers to be accepted.
+
+
+18. Appendix: Minimum Length Summary
+
+- Discovery datagram: exactly 5 bytes (payload == "START").
+- Headered datagram: at least 26 bytes (2-byte ProtocolFlag + 8-byte SequenceNumber + 8-byte QPC + 8-byte QPF). If fragmentation metadata is present, add 16 bytes (total >= 42).
+- Connection-id datagram: at least 39 bytes (2-byte ProtocolFlag + 37-byte NUL-terminated connection id string).
+
+Authors: protocol specification team

--- a/documents/media_streaming_protocol_spec_3way.md
+++ b/documents/media_streaming_protocol_spec_3way.md
@@ -1,0 +1,179 @@
+Media Streaming Protocol — 3-Way Handshake Conformance Specification
+
+Status: Informational
+
+Abstract
+
+This document specifies a minimal, precise, and implementation-independent protocol for discovery, session establishment using a three-way handshake, and media delivery over UDP datagrams. It preserves the existing headered datagram and control-frame formats while replacing the original single-way `START` discovery token with a TCP-style 3-way handshake that is implemented using headered control datagrams. The handshake is integrated into the same headered datagram namespace (ProtocolFlag values) so session establishment, control messages, and data frames share a unified parsing model.
+
+1. Terminology
+
+- Initiator: the endpoint that requests a stream from a Responder (typically the receiver).
+- Responder: the endpoint that supplies media data to an Initiator (typically the sender).
+- Datagram: a single UDP packet delivered as an atomic unit.
+- Packet tuple: (source IP, source port, destination IP, destination port) used to identify a logical session.
+- Sequence Number: unsigned 64-bit integer carried in the header and used for ordering and deduplication.
+- QPC: unsigned 64-bit sender timestamp captured from a high-resolution clock at send time.
+- QPF: unsigned 64-bit frequency value representing clock ticks per second for the clock used to capture QPC.
+- Headered Datagram: a datagram that begins with the fixed protocol header defined in section 4 followed by application payload bytes.
+- Control Frame: a headered datagram with a reserved control ProtocolFlag value indicating the payload is a control message rather than media data.
+
+2. Design Goals
+
+- Simplicity: minimal on-wire state for discovery and session establishment, and simple header layout for timing and ordering.
+- Interoperability: precise byte offsets and field sizes to allow independent implementations to interoperate.
+- Defensive parsing: clear validation rules preventing ambiguous parsing between control and data datagrams.
+- Unified framing: session establishment is performed using the same headered framing as data and other control messages (no separate "START" discovery token).
+
+3. Byte Order and Encoding
+
+All multi-byte integer fields in this protocol MUST be transmitted using little-endian byte order. Implementations MUST parse and generate fields using little-endian encoding; no alternate endianness is permitted for interoperable implementations.
+
+4. Datagram Types and Disambiguation
+
+An implementation MUST recognize the following datagram forms and disambiguate them exactly as specified. Implementations MUST test received datagrams in this order:
+
+- Connection-id Datagram: a control datagram consisting of ProtocolFlag value `0x1000` followed immediately by a NUL-terminated connection identifier string (37 bytes canonical). See section 7.
+- Headered Datagram (control or data): begins with the 26-byte protocol header (section 5) followed by payload bytes. Control frames are indicated by reserved ProtocolFlag values described below.
+
+Notes:
+- The previous specification used a 5-byte "START" discovery token that had no header. This document replaces that token with a 3-way handshake implemented as headered control frames. Implementations that previously relied on the lone 5-byte discovery payload MUST be updated to accept the new handshake frames; however, for backward compatibility a receiver MAY optionally accept the legacy 5-byte discovery token if explicitly configured to do so (see section 14).
+
+5. Header Layout (on-wire)
+
+Headered Datagrams use the following fixed on-wire byte layout (offsets are zero-based):
+
+- ProtocolFlag: 2 bytes, offset 0
+- SequenceNumber: 8 bytes, offset 2
+- QPC: 8 bytes, offset 10
+- QPF: 8 bytes, offset 18
+- Payload: variable, offset 26
+
+Total fixed header length: 26 bytes.
+
+Field descriptions:
+
+- ProtocolFlag (2 bytes): unsigned 16-bit value distinguishing datagram subtypes within the headered format. For headered datagrams this field MUST be one of the following values:
+  - `0x0000` — Standard data datagram with no fragmentation metadata.
+  - `0x0001` — Standard data datagram with the Fragmentation flag set; a 16-byte Fragment Metadata block MUST follow the fixed header.
+  - `0x0100` — Control frame: `SYN` (Initiator -> Responder) — begins a session handshake. The payload is a `SYN` control body (section 6.1).
+  - `0x0101` — Control frame: `SYN-ACK` (Responder -> Initiator) — acknowledges `SYN` and conveys responder state. The payload is a `SYN-ACK` control body (section 6.2).
+  - `0x0102` — Control frame: `ACK` (Initiator -> Responder) — completes the handshake. The payload is an `ACK` control body (section 6.3).
+
+Implementations MUST reject headered datagrams whose ProtocolFlag is any unsupported value and MUST record a validation error when such datagrams are received.
+
+- SequenceNumber (8 bytes): unsigned 64-bit integer assigned once per logical send. For control frames that are not associated with a logical media send, SequenceNumber SHOULD be set to zero.
+
+- QPC (8 bytes) and QPF (8 bytes): same semantics as in the base protocol — QPC is a sender clock sample; QPF is ticks-per-second for that clock. Control frames MAY populate these fields for telemetry but SHOULD set them to zero if not meaningful for the control message.
+
+6. Session Establishment — 3-Way Handshake
+
+This section defines a simple three-way handshake (SYN, SYN-ACK, ACK) carried inside headered control frames. The handshake associates the packet tuple with a session identifier and provides explicit semantics for deduplication flush and SequenceNumber reuse. The handshake is intentionally minimal and integrates with existing connection-id control datagrams.
+
+6.1. SYN (Initiator -> Responder)
+
+- Datagram: headered datagram with `ProtocolFlag == 0x0100`.
+- SequenceNumber: SHOULD be zero.
+- Payload (control body), little-endian layout:
+  - Version: 1 byte — protocol version (current value = 1).
+  - Flags: 1 byte — reserved bits for future use; currently 0.
+  - Reserved: 2 bytes — NUL for alignment.
+  - DesiredConnectionId: 37 bytes — optional NUL-terminated ASCII string the Initiator prefers as connection id (may be all zeros/NULs to request a responder-assigned id).
+  - OptionalOptions: variable — optional TLV-encoded options (length-prefixed) allowed but MUST be ignored by receivers that do not understand them.
+
+- Semantics: The Initiator sends `SYN` to request a stream from the Responder. Sending `SYN` indicates the Initiator's willingness to accept the Responder's stream on the tuple from which `SYN` was sent.
+
+- Retransmission: The Initiator MAY retransmit `SYN` periodically if no `SYN-ACK` is received; implementations SHOULD apply exponential backoff and limit retry attempts to avoid amplification.
+
+6.2. SYN-ACK (Responder -> Initiator)
+
+- Datagram: headered datagram with `ProtocolFlag == 0x0101`.
+- SequenceNumber: SHOULD be zero.
+- Payload (control body), little-endian layout:
+  - Version: 1 byte — protocol version (current value = 1).
+  - Flags: 1 byte — bitfield; bit 0 (0x01) = `Accept` (1=accept, 0=reject), other bits reserved.
+  - Reserved: 2 bytes — NUL for alignment.
+  - AssignedConnectionId: 37 bytes — NUL-terminated ASCII connection id assigned by Responder (if Accept=1). If Reject, this field MAY be all zeros or contain a diagnostic string.
+  - ReceiverOptions: variable — optional TLV-encoded options describing limits (e.g., max reassembly size) that the Responder supports; unknown TLVs MUST be ignored by the Initiator.
+
+- Semantics: On receipt of a valid `SYN`, the Responder MAY allocate resources and decide whether to accept or reject. If accepting, the Responder returns `SYN-ACK` with `Accept=1` and provides an `AssignedConnectionId`. The Responder SHOULD send `SYN-ACK` from the port and address it will use for subsequent streaming and SHOULD begin sending media datagrams once the handshake completes (see section 6.4 for ordering rules).
+
+6.3. ACK (Initiator -> Responder)
+
+- Datagram: headered datagram with `ProtocolFlag == 0x0102`.
+- SequenceNumber: SHOULD be zero.
+- Payload (control body), little-endian layout:
+  - Version: 1 byte — protocol version (current value = 1).
+  - Flags: 1 byte — reserved for future use.
+  - Reserved: 2 bytes — NUL for alignment.
+  - ConfirmedConnectionId: 37 bytes — the NUL-terminated connection id the Initiator acknowledges (typically the `AssignedConnectionId` from `SYN-ACK`).
+  - OptionalOptions: variable — optional TLV-encoded options, MUST be ignored if unknown.
+
+- Semantics: Receipt of `ACK` by the Responder completes the handshake. Upon receipt the Responder SHOULD consider the packet tuple bound to the acknowledged connection id and may begin or continue streaming media to the Initiator's tuple.
+
+6.4. Handshake Timing and Ordering Rules
+
+- Completion: The handshake is complete from the Responder's perspective when it receives the `ACK` acknowledging the `AssignedConnectionId`. The Initiator may consider the handshake complete when it receives a `SYN-ACK` with `Accept=1` (or optionally after it transmits `ACK`). Implementations SHOULD tolerate reordered or lost handshake datagrams using retransmission timers.
+
+- Data before completion: The Responder SHOULD NOT rely on having received an `ACK` before sending media; the Responder MAY begin sending media datagrams immediately after sending `SYN-ACK` (optimistic start). To avoid ambiguity, media datagrams MUST include the AssignedConnectionId via an explicit connection-id control datagram (section 7) sent by the Responder as the first datagram after `SYN-ACK`, or the Responder may include the ConnectionId in a small control header inside media datagrams using a reserved TLV (see Appendix A for extension guidance). Receivers MUST use the presence of a connection-id datagram or an explicit connection-id in control metadata to disambiguate session identity when media arrives before `ACK`.
+
+- Deduplication flush rule: Upon creating or changing the mapping between a packet tuple and a connection-id, implementations MUST flush deduplication and reassembly caches for that tuple. Specifically, when the Responder accepts a `SYN` and assigns a different ConnectionId for an existing tuple, the receiver MUST treat subsequent SequenceNumbers as new and not deduplicate against prior state for the same tuple. The `ACK` datagram also serves as a synchronization point for state transitions.
+
+7. Connection-id Datagram (control)
+
+- Format: The connection-id datagram remains a minimal control datagram and is NOT a headered data datagram payload type. Its on-wire layout is:
+  - ProtocolFlag: 2 bytes (value `0x1000`) at offset 0
+  - ConnectionIdString: 37 bytes at offsets 2..38 inclusive — canonical form is a 36-character UUID ASCII string followed by a NUL (0x00) terminator.
+
+- Minimum length: Receivers MUST validate that a connection-id datagram has length >= 39 bytes (2 + 37) before attempting extraction.
+
+- Extraction: Receivers MUST copy the first 37 bytes immediately following the ProtocolFlag and treat them as the NUL-terminated connection id string. Any trailing bytes beyond the 37-byte canonical field MAY be ignored.
+
+- Semantics/Purpose: Connection-id datagrams provide an explicit, minimal control mechanism to associate a packet tuple with an opaque connection identifier used for correlation, logging, or out-of-band telemetry. Typical approved uses:
+  - Responder sends a connection-id to the Initiator shortly after accepting a `SYN` to provide a stable identifier for the stream.
+  - Either endpoint may send a connection-id as a control message to update or reassign the identifier for a tuple when practical.
+  - Receivers use the connection id to correlate metrics, logs, and to map incoming packets to higher-level session state when tuple- or port-based correlation is insufficient.
+
+Implementations MUST NOT assume connection-id datagrams imply the presence of a 26-byte header or of sequence/telemetry fields; the two forms are disjoint by design.
+
+- Validation and treatment: Receivers MUST treat the connection-id field as an opaque identifier for correlation. Receivers MAY perform optional syntax validation (for example, validate the 36-byte portion matches conventional UUID textual syntax with hyphens) for diagnostics or policy enforcement, but MUST NOT reject or drop the datagram solely because the identifier does not parse as a UUID. Implementations MUST accept any 37-byte NUL-terminated string as a valid connection id for mapping and correlation purposes.
+
+- Session semantics: A change in the observed connection-id for a packet tuple SHOULD be interpreted as a session re-identification for that tuple. Receivers MUST treat different connection-id values as distinct logical sessions even when the 4-tuple is identical.
+
+- Security note: Connection-id values are supplied by remote endpoints and can be adversarially controlled. Receivers MUST NOT treat connection-id values as secrets or use them for access control decisions.
+
+8. Packet Reception and Validation
+
+When a receiver receives a UDP datagram it MUST perform these checks in order:
+
+1. If datagram length < 2, drop and record a validation error.
+2. Read the 2-byte ProtocolFlag at offset 0 (little-endian).
+ - If ProtocolFlag == `0x1000` (connection-id): verify datagram length >= 39; if shorter, drop and record a validation error. Otherwise extract the first 37 bytes after the ProtocolFlag as the NUL-terminated connection id string and process it (section 7).
+ - Else if ProtocolFlag is one of the defined headered flags (`0x0000`, `0x0001`, `0x0100`, `0x0101`, `0x0102`): verify datagram length >= 26 for headered datagrams; if shorter, drop and record a validation error. Then parse the header fields as below.
+ - Otherwise: treat ProtocolFlag as unknown, drop datagram and record a validation error.
+3. For headered datagrams: parse SequenceNumber (offset 2), QPC (offset 10), QPF (offset 18) as unsigned little-endian integers. Determine whether the fragmentation flag is set (ProtocolFlag bit `0x0001` for data frames). If set, verify datagram length >= 42 (26 + 16) and parse the 16-byte Fragment Metadata block: FragmentOffset (8 bytes) and TotalLength (8 bytes). The application payload begins at offset 26 (no-fragmentation) or 42 (with fragment metadata) and has length (datagram length − payload_offset).
+4. If the ProtocolFlag indicates a control frame (0x0100..0x0102), parse the control body according to the control frame layout (section 6) and handle handshake state transitions, validation, and optional options TLVs.
+5. All parsed fields MUST be validated as untrusted input before use.
+
+Receivers MUST not rely on any implicit bufferOffset; all offsets in this specification are absolute within the datagram payload as received from the transport.
+
+9. Sequence Assignment, Fragmentation, Ordering, and Reassembly
+
+- Sequence number granularity: The sender MUST allocate a single SequenceNumber for each logical send (logical buffer). All fragments produced while partitioning that logical buffer MUST carry the same SequenceNumber.
+
+- Fragment composition (extension): To enable unambiguous reassembly, this specification defines an optional per-fragment metadata block that immediately follows the 26-byte header when the sender sets the Fragmentation flag described below. The base header alone does not contain fragment positioning metadata; therefore, senders MUST choose one of the following strategies and advertise/implement it consistently:
+  - Inline Fragment Metadata (recommended, normative): The sender MUST set bit `0x0001` in the ProtocolFlag (i.e., ProtocolFlag & `0x0001` != 0) to indicate that a 16-byte Fragment Metadata block follows the fixed 26-byte header. The metadata block layout (little-endian) is:
+    - FragmentOffset: 8 bytes (unsigned 64-bit) — byte offset of this fragment's payload within the original logical buffer.
+    - TotalLength: 8 bytes (unsigned 64-bit) — total byte length of the original logical buffer.
+    The application payload begins immediately after the Fragment Metadata block at offset 42 (26 + 16).
+@@
+ - Deduplication: Receivers MUST detect and discard datagrams whose SequenceNumber indicates the logical send has already been accepted and processed. Implementations SHOULD maintain a bounded recent-sequence cache keyed by packet tuple and SequenceNumber.
+@@
+ - Reassembly timeout: Receivers MUST abort and discard incomplete reassembly state for a SequenceNumber if it remains incomplete for more than a configurable timeout (RECOMMENDED default 5000 ms). The receiver MUST record a timeout metric when this occurs.
+@@
+ - Deduplication cache and session restarts: Because senders may restart and reuse SequenceNumber ranges, implementations MUST adopt logic to avoid false-positive deduplication across distinct logical sessions. Receivers MUST flush or reset deduplication state for a packet tuple when one of the following explicit triggers occurs:
+  - Receiving a discovery `START` datagram for the tuple.
+  - Receiving a connection-id datagram for the tuple whose `connection-id` differs from the connection-id associated with the saved deduplication entries.
+
+ - Recommendation: include `connection-id` in the deduplication key when available. Prefer the key: `(tuple, connection-id, SequenceNumber)`. If `connection-id` is unknown, fall back to `(tuple, SequenceNumber)`. When using the fallback key, perform the flush rules above whenever a different `connection-id` or a discovery `START` token is later observed for the tuple so that deduplication state is reset for the new connection context.
+*** End Patch


### PR DESCRIPTION
This pull request introduces a comprehensive migration plan for transitioning the media streaming protocol from the legacy 5-byte `START` discovery model to a new, configurable 3-way handshake mechanism (SYN / SYN-ACK / ACK). The migration is designed to be backward compatible, with the new behavior gated behind a runtime flag, ensuring existing deployments are unaffected unless explicitly enabled. The plan details the steps, file locations, implementation guidance, and testing strategies required for a safe and incremental rollout.

The most important changes are:

**Protocol and Handshake Implementation:**
* Introduces new ProtocolFlag constants (`c_udpDatagramFlagSyn`, `c_udpDatagramFlagSynAck`, `c_udpDatagramFlagAck`) and helper functions (`MakeSynTask`, `MakeSynAckTask`, `MakeAckTask`, `ParseControlFrame`) to support the new handshake, with implementations in `ctsMediaStreamProtocol.hpp` and `ctsMediaStreamProtocol.cpp`.
* Updates send-side logic in `ctsIOPatternMediaStream.cpp` to optionally send a headered `SYN` control frame when the 3-way handshake is enabled, while preserving the legacy `START` behavior by default.
* Modifies receive-side parsing and handshake state management to recognize new control frames, manage handshake state transitions, and maintain compatibility with connection-id datagrams.

**Configuration and Back